### PR TITLE
add link to Join Us button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-    
+
     <head>
         <meta charset=utf-8>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -36,7 +36,7 @@
         <link rel="apple-touch-icon" sizes="72x72" href="/images/ico/favicon-72.png">
         <link rel="apple-touch-icon" href="/images/ico/favicon-57.png">
     </head>
-    
+
     <body>
         <div class="navbar">
             <div class="navbar-inner">
@@ -296,7 +296,7 @@
                         <div class="highlighted-box center">
                             <h1>Do you want to join the team?</h1>
                             <p>We're always looking for more hands to code. Don't hesitate to contribute by reporting an issue or pulling out some code!</p>
-                            <button class="button button-sp">Join Us</button>
+                            <a href="https://github.com/SickRage/SickRage" class="button">Join Us</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Currently the `Join Us` button doesn't link to anything so let's make it point to the SickRage Github repository.

Was considering linking to either the [SickRage repo](https://github.com/SickRage/SickRage) or to the [sickrage-issues](https://github.com/SickRage/sickrage-issues) one. What do you guys thing?