### PR TITLE
Network AVROTROS missing

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -180,6 +180,7 @@ aurora (AU):Australia/Sydney
 Australian Christian Channel:Australia/Sydney
 aux (CA):Canada/Eastern
 AVRO:Europe/Amsterdam
+AVROTROS:Europe/Amsterdam
 AWE (US):US/Eastern
 AXN (HK):Asia/Hong_Kong
 AXN (JP):Asia/Tokyo


### PR DESCRIPTION
Network AVROTROS missing in network_timezones.txt and also uploaded a logo for this network.

2015-12-28 10:58:19 INFO Thread-51 :: Network was not found in the network time zones: AVROTROS