### PR TITLE
Update network_timezones.txt

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1877,6 +1877,7 @@ Syndication:US/Eastern
 tagesschau24 (DE):Europe/Berlin
 Tai Seng Sat TV (US):US/Eastern
 Takbeer TV (UK):Europe/London
+Talpa, RTL4:Europe/Amsterdam
 Tapesh TV (US):US/Eastern
 TBN (Trinity Broadcasting Network):US/Eastern
 TBN Enlace (US):US/Eastern


### PR DESCRIPTION
Added Talpa, RTL4:Europe/Amsterdam for Dutch network
to fix:
2016-03-27 11:19:29 Thread-13 :: [1847f03] Missing time zone for network: Talpa, RTL4