### PR TITLE
network_timezones: add Yorkshire Television

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -2364,6 +2364,7 @@ Yomiuri TV (JP):Asia/Tokyo
 Yorin (NL):Europe/Amsterdam
 York Channel (UK):Europe/London
 Yorkshire Coast TV (UK):Europe/London
+Yorkshire Television:Europe/London
 YourTV Blackpool & Preston (UK):Europe/London
 YourTV Manchester (UK):Europe/London
 youtoo SOCIAL TV (US):US/Eastern


### PR DESCRIPTION
add Yorkshire Television (scraped by Reboot) with timezone of Europe/London