### PR TITLE
Adding exception for Flash (2014)

### DIFF
--- a/sb_tvdb_scene_exceptions/exceptions.txt
+++ b/sb_tvdb_scene_exceptions/exceptions.txt
@@ -469,4 +469,5 @@
 295516: 'The Family',
 260363: 'Mafias Greatest Hits',
 303236: 'Outsiders 2016',
-298277 'Bunkd',
+298277: 'Bunkd',
+279121: 'The Flash 2014'


### PR DESCRIPTION
Flash (2014) is published as The Flash 2014 on torrent sites.
