### PR TITLE
Link Line TV (Thailand) to Asia/Bangkok

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1154,6 +1154,7 @@ Lifetime (UK):Europe/London
 Lifetime (US):America/New_York
 Lifetime UK:Europe/London
 Lifetime:US/Eastern
+LINE TV (TH):Asia/Bangkok
 Liquidation Channel (US):US/Eastern
 Live Well NETWORK (US):US/Eastern
 Living Asia Channel (PH):Asia/Manila


### PR DESCRIPTION
Add missing Line TV channel to Asia/Bangkok.